### PR TITLE
fix: lift z-index for overlay and screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mytiki/tiki-sdk-js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "JS SDK for client-side integration with TIKI",
   "source": "dist/index.js",
   "license": "MIT",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tiki_sdk_js
 description: JS SDK for client-side integration with TIKI
-version: 1.0.4
+version: 1.0.5
 homepage: https://mytiki.com
 documentation: https://docs.mytiki.com/docs/sdk-overview
 repository: https://github.com/tiki/tiki-sdk-js

--- a/src/ui/elements/overlay/overlay.css
+++ b/src/ui/elements/overlay/overlay.css
@@ -13,4 +13,5 @@
   transform: translate(-50%, -50%);
   width: 100vw;
   height: 100vh;
+  z-index: 998;
 }

--- a/src/ui/screens/ending/ending.css
+++ b/src/ui/screens/ending/ending.css
@@ -17,6 +17,7 @@
   transform: translate(-50%, 0);
   font-family: var(--tiki-ending-font-family);
   border-radius: 2.5em 2.5em 0 0;
+  z-index: 999;
 }
 
 .tiki-ending-body {

--- a/src/ui/screens/learn-more/learn-more.css
+++ b/src/ui/screens/learn-more/learn-more.css
@@ -17,6 +17,7 @@
   transform: translate(-50%, -50%);
   width: 100vw;
   height: 100vh;
+  z-index: 999;
 }
 
 .tiki-learn-more-body {

--- a/src/ui/screens/offer-prompt/offer-prompt.css
+++ b/src/ui/screens/offer-prompt/offer-prompt.css
@@ -15,6 +15,7 @@
   transform: translate(-50%, 0);
   font-family: var(--tiki-offer-prompt-font-family);
   border-radius: 2.5em 2.5em 0 0;
+  z-index: 999;
 }
 
 .tiki-offer-prompt-body {

--- a/src/ui/screens/settings/settings.css
+++ b/src/ui/screens/settings/settings.css
@@ -17,6 +17,7 @@
   transform: translate(-50%, -50%);
   width: 100vw;
   height: 100vh;
+  z-index: 999;
 }
 
 .tiki-settings-body {

--- a/src/ui/screens/terms/terms.css
+++ b/src/ui/screens/terms/terms.css
@@ -16,6 +16,7 @@
   transform: translate(-50%, -50%);
   width: 100vw;
   height: 100vh;
+  z-index: 999;
 }
 
 .tiki-terms-body {


### PR DESCRIPTION
Websites that also use stacked divs with z-index were causing click propagation issues. Fixed by lifting the z-index for the overlay and all screens WAY up (998 + 999). Should give devs the flexibility they need to build their stacks since 99 is the standard for "must be on top" 