### PR TITLE
fix(ui): export elements and screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mytiki/tiki-sdk-js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mytiki/tiki-sdk-js",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.21.0",

--- a/src/ui/screens/screens.ts
+++ b/src/ui/screens/screens.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+export * as Ending from "./ending/ending";
+export * as LearnMore from "./learn-more/learn-more";
+export * as Prompt from "./offer-prompt/offer-prompt";
+export * as Settings from "./settings/settings";
+export * as Terms from "./terms/terms";

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -13,4 +13,5 @@
 export { Bullet } from "./bullet";
 export { Offer } from "./offer";
 export { Theme } from "./theme";
-// export * from "./elements/elements";
+export * from "./elements/elements";
+export * from "./screens/screens";


### PR DESCRIPTION
Add the elements and screens to the UI exports.

In order to use the UIs and create custom flows, like the one we are using in Shopify integration, I added the elements and the screens to the UI export. 

Now elements and screens can be accessed by:

TikiSdk.UI.Ending
TikiSdk.UI.LearnMore
TikiSdk.UI.Prompt
TikiSdk.UI.Settings
TikiSdk.UI.Terms
TikiSdk.UI.BackBtn
TikiSdk.UI.LearnMoreBtn
TikiSdk.UI.OfferCard
TikiSdk.UI.Overlay
TikiSdk.UI.TextBtn
TikiSdk.UI.TradeYourDataBadge
TikiSdk.UI.UsedFor
TikiSdk.UI.YourChoiceBadge

![Captura de Tela 2023-06-01 às 10 38 28](https://github.com/tiki/tiki-sdk-js/assets/8357343/b87e2bed-d56c-4878-8578-43d4c01db8bb)


- closes #75