### PR TITLE
fix: enable the usage of terms HTML source in UI.Flow

### DIFF
--- a/src/ui/flow.ts
+++ b/src/ui/flow.ts
@@ -15,6 +15,7 @@ import { FlowStep } from "./flow-step";
 import { Config } from "../config";
 import { Title, License } from "../trail/trail";
 import { Offer } from "./offer";
+import { LicenseRecord } from "../trail/license";
 
 const id = "tiki-offer";
 const overlayId = "tiki-offer-overlay";
@@ -72,20 +73,15 @@ async function goTo(
       break;
     }
     case FlowStep.terms: {
+      const offer = config._offers[0];
       const terms = await Terms.create(
         {
           src: config._offers[0]._terms,
+          isHtml: offer._termsIsHtml
         },
         async () => {
-          const offer = config._offers[0];
-          let titleRecord: Title.TitleRecord | undefined = Title.getByPtr(
-            offer._ptr
-          );
-          if (titleRecord === undefined) {
-            titleRecord = await Title.create(offer._ptr, offer._tags);
-          }
-          const licenseRecord: License.LicenseRecord = await License.create(
-            titleRecord.id,
+          const record: LicenseRecord = await License.create(
+            offer._ptr,
             offer._uses,
             offer._terms,
             offer._description,
@@ -93,7 +89,7 @@ async function goTo(
           );
           terms.remove();
           if (config._onAccept != undefined)
-            config._onAccept(config._offers[0], licenseRecord);
+            config._onAccept(config._offers[0], record);
           if (config._isAcceptEndingDisabled) goTo(FlowStep.none);
           else goTo(FlowStep.endingAccepted, config);
         },

--- a/src/ui/flow.ts
+++ b/src/ui/flow.ts
@@ -79,7 +79,6 @@ async function goTo(
           isHtml: offer._termsIsHtml
         },
         async () => {
-          const offer = config._offers[0];
           let titleRecord: Title.TitleRecord | undefined = Title.getByPtr(
             offer._ptr
           );

--- a/src/ui/flow.ts
+++ b/src/ui/flow.ts
@@ -75,8 +75,8 @@ async function goTo(
       const offer = config._offers[0];
       const terms = await Terms.create(
         {
-          src: config._offers[0]._terms,
-          isHtml: offer._termsIsHtml
+          src: config._offers[0]._terms.src,
+          isHtml: offer._terms.isHtml,
         },
         async () => {
           let titleRecord: Title.TitleRecord | undefined = Title.getByPtr(
@@ -88,7 +88,7 @@ async function goTo(
           const licenseRecord: License.LicenseRecord = await License.create(
             titleRecord.id,
             offer._uses,
-            offer._terms,
+            offer._terms.src,
             offer._description,
             offer._expiry
           );
@@ -155,7 +155,7 @@ async function goTo(
             const record: License.LicenseRecord = await License.create(
               titleRecord.id,
               [],
-              offer._terms,
+              offer._terms.src,
               offer._description,
               offer._expiry
             );
@@ -167,7 +167,7 @@ async function goTo(
             const record: License.LicenseRecord = await License.create(
               titleRecord.id,
               offer._uses,
-              offer._terms,
+              offer._terms.src,
               offer._description,
               offer._expiry
             );

--- a/src/ui/flow.ts
+++ b/src/ui/flow.ts
@@ -15,7 +15,6 @@ import { FlowStep } from "./flow-step";
 import { Config } from "../config";
 import { Title, License } from "../trail/trail";
 import { Offer } from "./offer";
-import { LicenseRecord } from "../trail/license";
 
 const id = "tiki-offer";
 const overlayId = "tiki-offer-overlay";
@@ -80,8 +79,15 @@ async function goTo(
           isHtml: offer._termsIsHtml
         },
         async () => {
-          const record: LicenseRecord = await License.create(
-            offer._ptr,
+          const offer = config._offers[0];
+          let titleRecord: Title.TitleRecord | undefined = Title.getByPtr(
+            offer._ptr
+          );
+          if (titleRecord === undefined) {
+            titleRecord = await Title.create(offer._ptr, offer._tags);
+          }
+          const licenseRecord: License.LicenseRecord = await License.create(
+            titleRecord.id,
             offer._uses,
             offer._terms,
             offer._description,
@@ -89,7 +95,7 @@ async function goTo(
           );
           terms.remove();
           if (config._onAccept != undefined)
-            config._onAccept(config._offers[0], record);
+            config._onAccept(config._offers[0], licenseRecord);
           if (config._isAcceptEndingDisabled) goTo(FlowStep.none);
           else goTo(FlowStep.endingAccepted, config);
         },

--- a/src/ui/offer.ts
+++ b/src/ui/offer.ts
@@ -7,6 +7,7 @@ import { LicenseUse } from "../trail/license-use";
 import { TitleTag } from "../trail/title-tag";
 import { Bullet } from "./bullet";
 import { Config } from "../config";
+import { Terms } from "./terms";
 
 /**
  * An Offer represents the Terms and Conditions for a particular offer. Acceptance of an offer by a user
@@ -27,11 +28,7 @@ export class Offer {
   /**
    * @hidden
    */
-  _terms?: string;
-  /**
-   * @hidden
-   */
-   _termsIsHtml: boolean = false;
+  _terms?: Terms;
   /**
    * @hidden
    */
@@ -100,7 +97,7 @@ export class Offer {
    *
    * @param src - A **link** (e.g. `'./terms.md'` ) to a markdown file containing the Terms or the HTML source text.
    * @param isHtml - Whether the 'src` parameter is a URL (false) or an HTML source text (true). Defaults to false.
-   * 
+   *
    * The specified Terms & Conditions are permanently recorded in the {@link Trail.License.LicenseRecord}. Supports **basic
    * markdown** syntax for speed and package size minimization.
    *
@@ -142,9 +139,11 @@ export class Offer {
    *     }
    * ```
    */
-  terms(src: string, isHtml: boolean = false): Offer {
-    this._terms = src;
-    this._termsIsHtml = isHtml;
+  terms(src: string, isHtml = false): Offer {
+    this._terms = {
+      src,
+      isHtml,
+    };
     return this;
   }
 

--- a/src/ui/offer.ts
+++ b/src/ui/offer.ts
@@ -98,8 +98,9 @@ export class Offer {
   /**
    * The legal Terms & Conditions of the Offer
    *
-   * @param src - A **link** (e.g. `'./terms.md'` ) to the markdown file containing the Terms.
-   *
+   * @param src - A **link** (e.g. `'./terms.md'` ) to a markdown file containing the Terms or the HTML source text.
+   * @param isHtml - Whether the 'src` parameter is a URL (false) or an HTML source text (true). Defaults to false.
+   * 
    * The specified Terms & Conditions are permanently recorded in the {@link Trail.License.LicenseRecord}. Supports **basic
    * markdown** syntax for speed and package size minimization.
    *

--- a/src/ui/offer.ts
+++ b/src/ui/offer.ts
@@ -31,6 +31,10 @@ export class Offer {
   /**
    * @hidden
    */
+   _termsIsHtml: boolean = false;
+  /**
+   * @hidden
+   */
   _reward?: string;
   /**
    * @hidden
@@ -137,8 +141,9 @@ export class Offer {
    *     }
    * ```
    */
-  terms(src: string): Offer {
+  terms(src: string, isHtml: boolean = false): Offer {
     this._terms = src;
+    this._termsIsHtml = isHtml;
     return this;
   }
 

--- a/src/ui/terms.ts
+++ b/src/ui/terms.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+export interface Terms {
+  src: string;
+  isHtml: boolean;
+}


### PR DESCRIPTION
### Description
The Terms screen can display the terms as an MD file URL or HTML source. 

### How it was
The `UI.Screen.Terms` already had the option for displaying HTML sources instead of downloading MD from an external URL.
https://github.com/tiki/tiki-sdk-js/blob/main/src/ui/screens/terms/terms.ts#L13-L23

But the `UI.Flow` did not use this parameter, which set the default in `TikiSdk.present()` as an URL:
https://github.com/tiki/tiki-sdk-js/blob/main/src/ui/flow.ts#L74-L78

### What changed
A new `isHtml` parameter was added to the `Offer.terms` method, which sets the `Offer._termsIsHTML` field
https://github.com/tiki/tiki-sdk-js/blob/fix/add-isTermsHtml/src/ui/offer.ts#L145-L148

The `UI.Flow` uses this parameter to initialize the `UI.Screen.Terms` in `isHTML` parameter.
https://github.com/tiki/tiki-sdk-js/blob/fix/add-isTermsHtml/src/ui/flow.ts#L77-L81

### Backward compatibility
The default value for `isHtml` across the code is `false` in order to keep backward compatibility with previous code.

closes #112