### PR TITLE
fix: bug with public key exponents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mytiki/tiki-sdk-js",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "JS SDK for client-side integration with TIKI",
   "main": "dist/index.js",
   "license": "MIT",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tiki_sdk_js
 description: JS SDK for client-side integration with TIKI
-version: 2.1.3
+version: 2.1.4
 homepage: https://mytiki.com
 documentation: https://docs.mytiki.com/docs/sdk-overview
 repository: https://github.com/tiki/tiki-sdk-js

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@
  * MIT license. See LICENSE file in root directory.
  */
 
-import KeyGen from "./trail/key-gen";
+import KeyGen from "./idp/key-gen";
 import { Offer } from "./ui/offer";
 import { Theme } from "./ui/theme";
 import { LicenseRecord } from "./trail/license-record";

--- a/src/idp/key-gen.ts
+++ b/src/idp/key-gen.ts
@@ -3,13 +3,15 @@
  * MIT license. See LICENSE file in root directory.
  */
 
+import { b64Encode } from "./util";
+
 export default async function (): Promise<string> {
   const crypto: SubtleCrypto = window.crypto.subtle;
   const keypair: CryptoKeyPair = await crypto.generateKey(
     {
       name: "RSASSA-PKCS1-v1_5",
       modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
+      publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
       hash: "SHA-256",
     },
     true,
@@ -19,5 +21,5 @@ export default async function (): Promise<string> {
     "pkcs8",
     keypair.privateKey
   );
-  return window.btoa(String.fromCharCode.apply(null, new Uint8Array(pkcs8)));
+  return b64Encode(new Uint8Array(pkcs8));
 }

--- a/src/idp/key.ts
+++ b/src/idp/key.ts
@@ -11,6 +11,7 @@ import { ReqSign } from "./req/req-sign";
 import { RspSign } from "./rsp/rsp-sign";
 import { ReqVerify } from "./req/req-verify";
 import { RspVerify } from "./rsp/rsp-verify";
+import { b64Decode, b64Encode } from "./util";
 
 export const create = (keyId: string, overwrite?: boolean): Promise<void> =>
   new Promise((resolve, reject) => {
@@ -99,9 +100,3 @@ export const verify = (
       reject(e);
     }
   });
-
-const b64Encode = (bytes: Uint8Array): string =>
-  btoa(bytes.reduce((acc, current) => acc + String.fromCharCode(current), ""));
-
-const b64Decode = (b64: string): Uint8Array =>
-  Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));

--- a/src/idp/util.ts
+++ b/src/idp/util.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+export const b64Encode = (bytes: Uint8Array): string =>
+  btoa(bytes.reduce((acc, current) => acc + String.fromCharCode(current), ""));
+
+export const b64Decode = (b64: string): Uint8Array =>
+  Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));


### PR DESCRIPTION
move from `[1,0,1]` to `[0x01,0x00,0x01]` for public key exponent (should always be 65537)